### PR TITLE
udpate SizePlugin version & add support for bot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1559,6 +1559,24 @@
         }
       }
     },
+    "axios": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
+          "dev": true
+        }
+      }
+    },
     "babel-loader": {
       "version": "8.0.6",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.6.tgz",
@@ -2061,6 +2079,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/chunkd/-/chunkd-1.0.0.tgz",
       "integrity": "sha512-xx3Pb5VF9QaqCotolyZ1ywFBgyuJmu6+9dLiqBxgelEse9Xsr3yUlpoX3O4Oh11M00GT2kYMsRByTKIMJW2Lkg==",
+      "dev": true
+    },
+    "ci-env": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/ci-env/-/ci-env-1.10.0.tgz",
+      "integrity": "sha512-kXGriGO7hW/uxDviPtUUehSG301RudEHUXNhAHeM5JM7iOSb6+tpXh+YqhcfxdCECvtfMNq0J7laOxAV3NsDng==",
       "dev": true
     },
     "ci-info": {
@@ -3443,6 +3467,32 @@
       "requires": {
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "dev": true,
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
       }
     },
     "for-in": {
@@ -8371,17 +8421,19 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "size-plugin": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/size-plugin/-/size-plugin-1.2.0.tgz",
-      "integrity": "sha512-lgB1vsrDM17fhmUrsS5vP1Tg+R57+AEMhms2B6iBuI3EHWVNQv3TANqixzwDOcMV5azX6DIqOaPu2+6CWw7b3Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/size-plugin/-/size-plugin-2.0.0.tgz",
+      "integrity": "sha512-0ww2iVo8RjZtafpuJocP7P+ueYLCepEwvw5kmcNQUqdYmjmpOre179PockiFapm0CinTNGEHsE8KI7OFZLHRUg==",
       "dev": true,
       "requires": {
-        "chalk": "^2.4.1",
+        "axios": "^0.19.0",
+        "chalk": "^2.4.2",
+        "ci-env": "^1.9.0",
         "escape-string-regexp": "^1.0.5",
-        "glob": "^7.1.2",
-        "gzip-size": "^5.0.0",
+        "glob": "^7.1.4",
+        "gzip-size": "^5.1.1",
         "minimatch": "^3.0.4",
-        "pretty-bytes": "^5.1.0",
+        "pretty-bytes": "^5.3.0",
         "util.promisify": "^1.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "nodemon": "^1.19.1",
     "nodemon-webpack-plugin": "^4.0.8",
     "npm-run-all": "^4.1.5",
-    "size-plugin": "^1.2.0",
+    "size-plugin": "^2.0.0",
     "source-map-loader": "^0.2.4",
     "webpack": "^4.35.3",
     "webpack-cli": "^3.3.5",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,7 +43,7 @@ module.exports = {
       verbose: false
     }),
     new DuplicatePackageCheckerPlugin(),
-    new SizePlugin(),
+    new SizePlugin({publish:true}),
     new WebpackBar(),
     new webpack.BannerPlugin({ banner: "#!/usr/bin/env node", raw: true })
   ]


### PR DESCRIPTION
👋
I noticed `repo-genesis-lib` is using [size-plugin](https://github.com/GoogleChromeLabs/size-plugin) .

I have created a [bot](https://github.com/kuldeepkeshwar/size-plugin-bot), which works with  [size-plugin](https://github.com/GoogleChromeLabs/size-plugin) and comments the sizes of the assets and the changes since the last build into the relevant PR

I have done the required configuration in pr (updating `size-plugin@2.0.0` & turn on `publish` flag)

Action item: 
- install [bot](https://github.com/kuldeepkeshwar/size-plugin-bot)